### PR TITLE
Fix team leader permissions for DAO management

### DIFF
--- a/backend-express/data/mockDaos.ts
+++ b/backend-express/data/mockDaos.ts
@@ -9,13 +9,13 @@ export const serverMockDaos = [
     dateDepot: "2025-08-20",
     equipe: [
       {
-        id: "1",
+        id: "2",
         name: "Marie Dubois",
         role: "chef_equipe" as const,
         email: "marie.dubois@2snd.fr",
       },
       {
-        id: "2",
+        id: "3",
         name: "Pierre Martin",
         role: "membre_equipe" as const,
         email: "pierre.martin@2snd.fr",
@@ -27,9 +27,9 @@ export const serverMockDaos = [
         name: "Résumé sommaire DAO et Création du drive",
         progress: 100,
         isApplicable: true,
-        assignedTo: "1",
+        assignedTo: "2",
         comment: "",
-        lastUpdatedBy: "1",
+        lastUpdatedBy: "2",
         lastUpdatedAt: new Date().toISOString(),
       },
       {
@@ -37,9 +37,9 @@ export const serverMockDaos = [
         name: "Demande de caution et garanties",
         progress: 75,
         isApplicable: true,
-        assignedTo: "2",
+        assignedTo: "3",
         comment: "",
-        lastUpdatedBy: "1",
+        lastUpdatedBy: "2",
         lastUpdatedAt: new Date().toISOString(),
       },
       {
@@ -133,13 +133,13 @@ export const serverMockDaos = [
     dateDepot: "2025-08-10",
     equipe: [
       {
-        id: "4",
+        id: "5",
         name: "Jean Moreau",
         role: "chef_equipe" as const,
         email: "jean.moreau@2snd.fr",
       },
       {
-        id: "3",
+        id: "6",
         name: "Sophie Laurent",
         role: "membre_equipe" as const,
         email: "sophie.laurent@2snd.fr",
@@ -245,13 +245,13 @@ export const serverMockDaos = [
     dateDepot: "2025-08-18",
     equipe: [
       {
-        id: "1",
+        id: "2",
         name: "Marie Dubois",
         role: "chef_equipe" as const,
         email: "marie.dubois@2snd.fr",
       },
       {
-        id: "3",
+        id: "6",
         name: "Sophie Laurent",
         role: "membre_equipe" as const,
         email: "sophie.laurent@2snd.fr",
@@ -362,7 +362,7 @@ export const serverMockDaos = [
     dateDepot: "2025-08-17",
     equipe: [
       {
-        id: "2",
+        id: "3",
         name: "Pierre Martin",
         role: "chef_equipe" as const,
         email: "pierre.martin@2snd.fr",

--- a/backend-express/middleware/auth.ts
+++ b/backend-express/middleware/auth.ts
@@ -102,18 +102,24 @@ export const requireAdmin = authorize(["admin"]);
 export function requireDaoLeaderOrAdmin(paramKey: string) {
   return (req: Request, res: Response, next: NextFunction) => {
     if (!req.user) {
-      return res.status(401).json({ error: "Authentication required", code: "NO_USER_CONTEXT" });
+      return res
+        .status(401)
+        .json({ error: "Authentication required", code: "NO_USER_CONTEXT" });
     }
     // Admin passes immediately
     if (req.user.role === "admin") return next();
 
     const daoId = req.params[paramKey];
     if (!daoId) {
-      return res.status(400).json({ error: "DAO ID missing", code: "MISSING_DAO_ID" });
+      return res
+        .status(400)
+        .json({ error: "DAO ID missing", code: "MISSING_DAO_ID" });
     }
     const dao = daoStorage.findById(daoId);
     if (!dao) {
-      return res.status(404).json({ error: "DAO not found", code: "DAO_NOT_FOUND" });
+      return res
+        .status(404)
+        .json({ error: "DAO not found", code: "DAO_NOT_FOUND" });
     }
 
     const isLeader = dao.equipe.some(
@@ -121,7 +127,9 @@ export function requireDaoLeaderOrAdmin(paramKey: string) {
     );
 
     if (!isLeader) {
-      return res.status(403).json({ error: "Insufficient permissions", code: "NOT_LEADER" });
+      return res
+        .status(403)
+        .json({ error: "Insufficient permissions", code: "NOT_LEADER" });
     }
 
     next();

--- a/backend-express/routes/dao-simple.ts
+++ b/backend-express/routes/dao-simple.ts
@@ -3,10 +3,10 @@ import { z } from "zod";
 import { daoStorage } from "../data/daoStorage";
 import {
   authenticate,
-  requireUser,
   requireAdmin,
   auditLog,
   sensitiveOperationLimit,
+  requireDaoLeaderOrAdmin,
 } from "../middleware/auth";
 import { devLog } from "../utils/devLog";
 import { DEFAULT_TASKS } from "@shared/dao";
@@ -275,7 +275,7 @@ router.post(
 router.put(
   "/:id",
   authenticate,
-  requireUser,
+  requireDaoLeaderOrAdmin("id"),
   auditLog("UPDATE_DAO"),
   (req, res) => {
     try {
@@ -426,7 +426,7 @@ router.delete(
 router.put(
   "/:id/tasks/reorder",
   authenticate,
-  requireUser,
+  requireDaoLeaderOrAdmin("id"),
   auditLog("REORDER_TASKS"),
   (req, res) => {
     try {
@@ -508,7 +508,7 @@ router.put(
 router.put(
   "/:id/tasks/:taskId",
   authenticate,
-  requireUser,
+  requireDaoLeaderOrAdmin("id"),
   auditLog("UPDATE_TASK"),
   (req, res) => {
     try {

--- a/backend-express/routes/tasks.ts
+++ b/backend-express/routes/tasks.ts
@@ -1,7 +1,7 @@
 import express from "express";
 import { z } from "zod";
 import { daoStorage } from "../data/daoStorage";
-import { authenticate, requireAdmin, auditLog } from "../middleware/auth";
+import { authenticate, requireDaoLeaderOrAdmin, auditLog } from "../middleware/auth";
 import type { DaoTask } from "@shared/dao";
 
 const router = express.Router();
@@ -28,7 +28,7 @@ function sanitizeString(input: string): string {
 router.post(
   "/:daoId/tasks",
   authenticate,
-  requireAdmin,
+  requireDaoLeaderOrAdmin("daoId"),
   auditLog("ADD_TASK"),
   (req, res) => {
     try {
@@ -107,7 +107,7 @@ router.post(
 router.put(
   "/:daoId/tasks/:taskId/name",
   authenticate,
-  requireAdmin,
+  requireDaoLeaderOrAdmin("daoId"),
   auditLog("UPDATE_TASK_NAME"),
   (req, res) => {
     try {
@@ -188,7 +188,7 @@ router.put(
 router.delete(
   "/:daoId/tasks/:taskId",
   authenticate,
-  requireAdmin,
+  requireDaoLeaderOrAdmin("daoId"),
   auditLog("DELETE_TASK"),
   (req, res) => {
     try {

--- a/backend-express/routes/tasks.ts
+++ b/backend-express/routes/tasks.ts
@@ -1,7 +1,11 @@
 import express from "express";
 import { z } from "zod";
 import { daoStorage } from "../data/daoStorage";
-import { authenticate, requireDaoLeaderOrAdmin, auditLog } from "../middleware/auth";
+import {
+  authenticate,
+  requireDaoLeaderOrAdmin,
+  auditLog,
+} from "../middleware/auth";
 import type { DaoTask } from "@shared/dao";
 
 const router = express.Router();

--- a/backend-mongodb/src/index.ts
+++ b/backend-mongodb/src/index.ts
@@ -49,8 +49,15 @@ app.use(express.urlencoded({ extended: true, limit: "10mb" }));
 // Logging middleware
 app.use(logger);
 
-// Health check endpoint
+// Health check endpoints
 app.get("/health", (req, res) => {
+  res.json({
+    status: "OK",
+    timestamp: new Date().toISOString(),
+    uptime: process.uptime(),
+  });
+});
+app.get("/api/health", (req, res) => {
   res.json({
     status: "OK",
     timestamp: new Date().toISOString(),

--- a/backend-mongodb/src/index.ts
+++ b/backend-mongodb/src/index.ts
@@ -70,8 +70,8 @@ app.use("/api/auth", authRoutes);
 app.use("/api/dao", daoRoutes);
 app.use("/api/users", userRoutes);
 
-// 404 handler
-app.use("*", (req, res) => {
+// 404 handler (Express v5: no wildcard string)
+app.use((req, res) => {
   res.status(404).json({
     error: "Route not found",
     path: req.originalUrl,

--- a/backend-mongodb/src/index.ts
+++ b/backend-mongodb/src/index.ts
@@ -17,6 +17,8 @@ import userRoutes from "./routes/user.js";
 dotenv.config();
 
 const app = express();
+// Trust proxy (fix express-rate-limit behind proxies)
+app.set("trust proxy", 1);
 const PORT = process.env.PORT || 5000;
 
 // Connect to MongoDB

--- a/backend-mongodb/src/scripts/db-queries.ts
+++ b/backend-mongodb/src/scripts/db-queries.ts
@@ -14,7 +14,8 @@ import mongoose from "mongoose";
 import { DaoModel } from "../models/Dao.js";
 import { UserModel } from "../models/User.js";
 
-const MONGODB_URI = process.env.MONGODB_URI || "mongodb://localhost:27017/dao-management";
+const MONGODB_URI =
+  process.env.MONGODB_URI || "mongodb://localhost:27017/dao-management";
 
 async function connect() {
   if (mongoose.connection.readyState === 0) {
@@ -46,7 +47,9 @@ export async function findDaoByNumero(numeroListe: string) {
 export async function listDaosForYear(year: number) {
   await connect();
   const re = new RegExp(`^DAO-${year}-\\d{3}$`);
-  const daos = await DaoModel.find({ numeroListe: re }).sort({ createdAt: -1 }).lean();
+  const daos = await DaoModel.find({ numeroListe: re })
+    .sort({ createdAt: -1 })
+    .lean();
   console.log(`📅 DAOs for ${year}:`, daos.length);
   return daos;
 }
@@ -57,16 +60,40 @@ export async function createDao(input: {
   reference: string;
   autoriteContractante: string;
   dateDepot: string; // ISO string
-  equipe: { id: string; name: string; role: "chef_equipe" | "membre_equipe"; email?: string }[];
-  tasks: { id: number; name: string; isApplicable: boolean; progress?: number | null; comment?: string; assignedTo?: string }[];
+  equipe: {
+    id: string;
+    name: string;
+    role: "chef_equipe" | "membre_equipe";
+    email?: string;
+  }[];
+  tasks: {
+    id: number;
+    name: string;
+    isApplicable: boolean;
+    progress?: number | null;
+    comment?: string;
+    assignedTo?: string;
+  }[];
 }) {
   await connect();
-  const dao = await DaoModel.create({ ...input, createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() });
+  const dao = await DaoModel.create({
+    ...input,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  });
   console.log("✨ Created DAO:", dao.numeroListe);
   return dao.toJSON();
 }
 
-export async function updateDao(numeroListe: string, updates: Partial<{ objetDossier: string; reference: string; autoriteContractante: string; dateDepot: string }>) {
+export async function updateDao(
+  numeroListe: string,
+  updates: Partial<{
+    objetDossier: string;
+    reference: string;
+    autoriteContractante: string;
+    dateDepot: string;
+  }>,
+) {
   await connect();
   const dao = await DaoModel.findOneAndUpdate(
     { numeroListe },
@@ -118,7 +145,10 @@ export async function assignmentsForUser(memberId: string) {
 // ----- USERS & CONNECTIONS -----
 export async function listUsers() {
   await connect();
-  const users = await UserModel.find().select("-password").sort({ createdAt: -1 }).lean();
+  const users = await UserModel.find()
+    .select("-password")
+    .sort({ createdAt: -1 })
+    .lean();
   console.log("👥 Users:", users.length);
   return users;
 }

--- a/backend-mongodb/src/scripts/db-queries.ts
+++ b/backend-mongodb/src/scripts/db-queries.ts
@@ -1,0 +1,166 @@
+/*
+  Usage: This script contains ready-to-run examples for MongoDB with Mongoose.
+  - It connects using MONGODB_URI (default: mongodb://localhost:27017/dao-management)
+  - It showcases common queries for:
+    • DAOs (listing, filtering, creation, updates, deletions)
+    • Assignments (tasks assigned to team members)
+    • Users and recent connections (lastLogin)
+
+  You can run specific functions from a REPL or execute the whole file with: tsx backend-mongodb/src/scripts/db-queries.ts
+  IMPORTANT: Notifications in this app are managed client-side (localStorage). This script derives “assignment notifications” from DAO/task data as an example of how a notifications collection could look like server-side.
+*/
+
+import mongoose from "mongoose";
+import { DaoModel } from "../models/Dao.js";
+import { UserModel } from "../models/User.js";
+
+const MONGODB_URI = process.env.MONGODB_URI || "mongodb://localhost:27017/dao-management";
+
+async function connect() {
+  if (mongoose.connection.readyState === 0) {
+    await mongoose.connect(MONGODB_URI);
+    console.log("✅ Connected to:", mongoose.connection.name);
+  }
+}
+
+async function disconnect() {
+  await mongoose.disconnect();
+  console.log("🔌 Disconnected");
+}
+
+// ----- DAO QUERIES -----
+export async function listDaos() {
+  await connect();
+  const daos = await DaoModel.find().sort({ createdAt: -1 }).lean();
+  console.log("📦 DAOs:", daos.length);
+  return daos;
+}
+
+export async function findDaoByNumero(numeroListe: string) {
+  await connect();
+  const dao = await DaoModel.findOne({ numeroListe }).lean();
+  console.log("🔎 DAO: ", dao?.numeroListe || "not found");
+  return dao;
+}
+
+export async function listDaosForYear(year: number) {
+  await connect();
+  const re = new RegExp(`^DAO-${year}-\\d{3}$`);
+  const daos = await DaoModel.find({ numeroListe: re }).sort({ createdAt: -1 }).lean();
+  console.log(`📅 DAOs for ${year}:`, daos.length);
+  return daos;
+}
+
+export async function createDao(input: {
+  numeroListe: string;
+  objetDossier: string;
+  reference: string;
+  autoriteContractante: string;
+  dateDepot: string; // ISO string
+  equipe: { id: string; name: string; role: "chef_equipe" | "membre_equipe"; email?: string }[];
+  tasks: { id: number; name: string; isApplicable: boolean; progress?: number | null; comment?: string; assignedTo?: string }[];
+}) {
+  await connect();
+  const dao = await DaoModel.create({ ...input, createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() });
+  console.log("✨ Created DAO:", dao.numeroListe);
+  return dao.toJSON();
+}
+
+export async function updateDao(numeroListe: string, updates: Partial<{ objetDossier: string; reference: string; autoriteContractante: string; dateDepot: string }>) {
+  await connect();
+  const dao = await DaoModel.findOneAndUpdate(
+    { numeroListe },
+    { ...updates, updatedAt: new Date().toISOString() },
+    { new: true },
+  ).lean();
+  console.log("📝 Updated DAO:", numeroListe, Boolean(dao));
+  return dao;
+}
+
+export async function deleteDao(numeroListe: string) {
+  await connect();
+  const res = await DaoModel.deleteOne({ numeroListe });
+  console.log("🗑️ Deleted:", numeroListe, res.deletedCount);
+  return res.deletedCount === 1;
+}
+
+// ----- ASSIGNMENTS (from DAO tasks) -----
+export async function listAssignments() {
+  await connect();
+  const daos = await DaoModel.find().lean();
+  const assignments = daos.flatMap((dao) =>
+    dao.tasks
+      .filter((t) => t.assignedTo)
+      .map((t) => {
+        const member = dao.equipe.find((m) => m.id === t.assignedTo);
+        return {
+          daoId: (dao as any).id || (dao as any)._id?.toString(),
+          numeroListe: dao.numeroListe,
+          taskId: t.id,
+          taskName: t.name,
+          assignedTo: t.assignedTo,
+          assignedToName: member?.name,
+          lastUpdatedAt: t.lastUpdatedAt,
+        };
+      }),
+  );
+  console.log("🧩 Assignments:", assignments.length);
+  return assignments;
+}
+
+export async function assignmentsForUser(memberId: string) {
+  const all = await listAssignments();
+  const mine = all.filter((a) => a.assignedTo === memberId);
+  console.log(`🙋 Assignments for ${memberId}:`, mine.length);
+  return mine;
+}
+
+// ----- USERS & CONNECTIONS -----
+export async function listUsers() {
+  await connect();
+  const users = await UserModel.find().select("-password").sort({ createdAt: -1 }).lean();
+  console.log("👥 Users:", users.length);
+  return users;
+}
+
+export async function recentConnections(limit = 10) {
+  await connect();
+  const users = await UserModel.find({ lastLogin: { $ne: null } })
+    .select("name email role lastLogin")
+    .sort({ lastLogin: -1 })
+    .limit(limit)
+    .lean();
+  console.log("🔐 Recent logins:", users.length);
+  return users;
+}
+
+// ----- DERIVED NOTIFICATIONS (from assignments) -----
+export async function derivedAssignmentNotifications() {
+  const items = await listAssignments();
+  const notifications = items.map((a) => ({
+    userId: a.assignedTo,
+    title: `Nouvelle assignation: ${a.taskName}`,
+    message: `Vous avez été assigné(e) à la tâche \"${a.taskName}\" pour ${a.numeroListe}`,
+    createdAt: a.lastUpdatedAt || new Date().toISOString(),
+    data: { daoId: a.daoId, numeroListe: a.numeroListe, taskId: a.taskId },
+  }));
+  console.log("🔔 Derived notifications:", notifications.length);
+  return notifications;
+}
+
+// Demo runner when executed directly
+if (import.meta.url === `file://${process.argv[1]}`) {
+  (async () => {
+    try {
+      await listDaos();
+      await listUsers();
+      await recentConnections(5);
+      await listAssignments();
+      await derivedAssignmentNotifications();
+    } catch (e) {
+      console.error(e);
+    } finally {
+      await disconnect();
+    }
+  })();
+}

--- a/frontend/components/AddTaskButton.tsx
+++ b/frontend/components/AddTaskButton.tsx
@@ -10,17 +10,19 @@ interface AddTaskButtonProps {
     newTask: Omit<DaoTask, "id" | "lastUpdatedAt" | "lastUpdatedBy">,
   ) => void;
   existingTaskIds: number[];
+  canManage?: boolean;
 }
 
 export default function AddTaskButton({
   onTaskAdd,
   existingTaskIds,
+  canManage = false,
 }: AddTaskButtonProps) {
   const { isAdmin } = useAuth();
   const [showDialog, setShowDialog] = useState(false);
 
-  // Only show for admin users
-  if (!isAdmin()) {
+  // Show for admin or manager (team lead)
+  if (!isAdmin() && !canManage) {
     return null;
   }
 

--- a/frontend/components/TaskAssignmentDialog.tsx
+++ b/frontend/components/TaskAssignmentDialog.tsx
@@ -46,6 +46,7 @@ interface TaskAssignmentDialogProps {
   onAssignmentChange: (memberId?: string) => void;
   onTeamUpdate?: (newTeam: TeamMember[]) => void;
   taskName: string;
+  canManage?: boolean;
 }
 
 // Helper function to convert User to TeamMember
@@ -65,6 +66,7 @@ export default function TaskAssignmentDialog({
   onAssignmentChange,
   onTeamUpdate,
   taskName,
+  canManage = false,
 }: TaskAssignmentDialogProps) {
   const [open, setOpen] = useState(false);
   const [selectedMember, setSelectedMember] = useState<string | undefined>(
@@ -185,6 +187,17 @@ export default function TaskAssignmentDialog({
   const currentMember = actualTeamMembers.find(
     (m) => m.id === currentAssignedTo,
   );
+
+  // Read-only view if user cannot manage assignments
+  if (!canManage) {
+    return currentMember ? (
+      <span className="inline-flex items-center rounded-md border border-input bg-yellow-100 px-2.5 py-0.5 text-xs font-semibold text-yellow-800">
+        {currentMember.name}
+      </span>
+    ) : (
+      <span className="text-xs text-muted-foreground">Non assigné</span>
+    );
+  }
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>

--- a/frontend/components/TaskMenuButton.tsx
+++ b/frontend/components/TaskMenuButton.tsx
@@ -16,19 +16,21 @@ interface TaskMenuButtonProps {
   task: DaoTask;
   onTaskUpdate: (taskId: number, updates: Partial<DaoTask>) => void;
   onTaskDelete: (taskId: number) => void;
+  canManage?: boolean;
 }
 
 export default function TaskMenuButton({
   task,
   onTaskUpdate,
   onTaskDelete,
+  canManage = false,
 }: TaskMenuButtonProps) {
   const { isAdmin } = useAuth();
   const [showEditDialog, setShowEditDialog] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
 
-  // Only show for admin users
-  if (!isAdmin()) {
+  // Show for admin or manager (team lead)
+  if (!isAdmin() && !canManage) {
     return null;
   }
 

--- a/frontend/components/TaskRow.tsx
+++ b/frontend/components/TaskRow.tsx
@@ -54,6 +54,7 @@ export function TaskRow({
   onDrop,
 }: TaskRowProps) {
   const { user, isAdmin } = useAuth();
+  const canManage = isAdmin() || availableMembers.some((m) => m.id === user?.id && m.role === "chef_equipe");
   const [isEditing, setIsEditing] = useState(false);
   const [tempProgress, setTempProgress] = useState(task.progress || 0);
   const [tempComment, setTempComment] = useState(task.comment || "");

--- a/frontend/components/TaskRow.tsx
+++ b/frontend/components/TaskRow.tsx
@@ -367,6 +367,7 @@ export function TaskRow({
                 onAssignmentChange(task.id, memberId)
               }
               taskName={task.name}
+              canManage={canManage}
             />
           </div>
 
@@ -400,20 +401,9 @@ export function TaskRow({
                 onAssignmentChange(task.id, memberId)
               }
               taskName={task.name}
+              canManage={canManage}
             />
-            <Button
-              size="sm"
-              variant="outline"
-              onClick={() => setIsEditing(true)}
-              className="text-xs"
-            >
-              Modifier
-            </Button>
-          </div>
-
-          {/* Action Buttons (Desktop) */}
-          <div className="hidden sm:flex items-center justify-between pt-2 border-t border-gray-100">
-            <div className="flex items-center gap-2">
+            {canManage && (
               <Button
                 size="sm"
                 variant="outline"
@@ -422,6 +412,22 @@ export function TaskRow({
               >
                 Modifier
               </Button>
+            )}
+          </div>
+
+          {/* Action Buttons (Desktop) */}
+          <div className="hidden sm:flex items-center justify-between pt-2 border-t border-gray-100">
+            <div className="flex items-center gap-2">
+              {canManage && (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => setIsEditing(true)}
+                  className="text-xs"
+                >
+                  Modifier
+                </Button>
+              )}
             </div>
             <TaskMenuButton
               task={task}

--- a/frontend/components/TaskRow.tsx
+++ b/frontend/components/TaskRow.tsx
@@ -136,7 +136,7 @@ export function TaskRow({
     return (
       <div
         ref={dragRef}
-        draggable={isAdmin()}
+        draggable={canManage}
         onDragStart={handleDragStart}
         onDragEnd={handleDragEnd}
         onDragOver={handleDragOver}
@@ -144,7 +144,7 @@ export function TaskRow({
         onDrop={handleDrop}
         className={cn(
           "bg-white rounded-lg border p-3 sm:p-4 transition-all duration-200",
-          isAdmin() && "hover:cursor-move",
+          canManage && "hover:cursor-move",
           isDragging && "opacity-50 transform rotate-1",
           isDragOver && "border-blue-500 bg-blue-50",
         )}
@@ -163,7 +163,7 @@ export function TaskRow({
           <div className="flex items-center justify-between pt-2 border-t border-gray-100">
             <span className="text-xs text-muted-foreground">Applicable:</span>
             <div className="flex items-center gap-2">
-              {isAdmin() ? (
+              {canManage ? (
                 <Switch
                   checked={task.isApplicable}
                   onCheckedChange={(checked) =>
@@ -194,7 +194,7 @@ export function TaskRow({
             </h4>
             <div className="flex items-center gap-2">
               <span className="text-xs text-muted-foreground">Applicable:</span>
-              {isAdmin() ? (
+              {canManage ? (
                 <Switch
                   checked={task.isApplicable}
                   onCheckedChange={(checked) =>
@@ -220,15 +220,15 @@ export function TaskRow({
   return (
     <div
       ref={dragRef}
-      draggable={isAdmin()}
-      onDragStart={handleDragStart}
+        draggable={canManage}
+        onDragStart={handleDragStart}
       onDragEnd={handleDragEnd}
       onDragOver={handleDragOver}
       onDragLeave={handleDragLeave}
       onDrop={handleDrop}
       className={cn(
         "bg-white rounded-lg border p-3 sm:p-4 transition-all duration-200",
-        isAdmin() && "hover:cursor-move",
+        canManage && "hover:cursor-move",
         isDragging && "opacity-50 transform rotate-1 shadow-lg",
         isDragOver && "border-blue-500 bg-blue-50",
       )}
@@ -247,7 +247,7 @@ export function TaskRow({
         <div className="flex items-center justify-between pt-2 border-t border-gray-100">
           <span className="text-xs text-muted-foreground">Applicable:</span>
           <div className="flex items-center gap-2">
-            {isAdmin() ? (
+            {canManage ? (
               <Switch
                 checked={task.isApplicable}
                 onCheckedChange={(checked) =>
@@ -278,7 +278,7 @@ export function TaskRow({
           <div className="flex items-center gap-3 ml-4">
             <div className="flex items-center gap-2">
               <span className="text-xs text-muted-foreground">Applicable:</span>
-              {isAdmin() ? (
+              {canManage ? (
                 <Switch
                   checked={task.isApplicable}
                   onCheckedChange={(checked) =>
@@ -427,6 +427,7 @@ export function TaskRow({
               task={task}
               onTaskUpdate={onTaskUpdate}
               onTaskDelete={onTaskDelete}
+              canManage={canManage}
             />
           </div>
 

--- a/frontend/components/TaskRow.tsx
+++ b/frontend/components/TaskRow.tsx
@@ -54,7 +54,9 @@ export function TaskRow({
   onDrop,
 }: TaskRowProps) {
   const { user, isAdmin } = useAuth();
-  const canManage = isAdmin() || availableMembers.some((m) => m.id === user?.id && m.role === "chef_equipe");
+  const canManage =
+    isAdmin() ||
+    availableMembers.some((m) => m.id === user?.id && m.role === "chef_equipe");
   const [isEditing, setIsEditing] = useState(false);
   const [tempProgress, setTempProgress] = useState(task.progress || 0);
   const [tempComment, setTempComment] = useState(task.comment || "");
@@ -220,8 +222,8 @@ export function TaskRow({
   return (
     <div
       ref={dragRef}
-        draggable={canManage}
-        onDragStart={handleDragStart}
+      draggable={canManage}
+      onDragStart={handleDragStart}
       onDragEnd={handleDragEnd}
       onDragOver={handleDragOver}
       onDragLeave={handleDragLeave}

--- a/frontend/pages/DaoDetail.tsx
+++ b/frontend/pages/DaoDetail.tsx
@@ -1091,6 +1091,7 @@ export default function DaoDetail() {
               <AddTaskButton
                 onTaskAdd={handleTaskAdd}
                 existingTaskIds={dao.tasks.map((t) => t.id)}
+                canManage={isAdmin() || dao.equipe.some((m) => m.id === user?.id && m.role === "chef_equipe")}
               />
             </div>
 

--- a/frontend/pages/DaoDetail.tsx
+++ b/frontend/pages/DaoDetail.tsx
@@ -429,8 +429,8 @@ export default function DaoDetail() {
 
     try {
       // Find current positions
-      const draggedIndex = dao.tasks.findIndex(t => t.id === draggedTaskId);
-      const targetIndex = dao.tasks.findIndex(t => t.id === targetTaskId);
+      const draggedIndex = dao.tasks.findIndex((t) => t.id === draggedTaskId);
+      const targetIndex = dao.tasks.findIndex((t) => t.id === targetTaskId);
 
       if (draggedIndex === -1 || targetIndex === -1) {
         return;
@@ -442,10 +442,10 @@ export default function DaoDetail() {
       newTasks.splice(targetIndex, 0, movedTask);
 
       // Update local state immediately for better UX
-      setDao(prev => prev ? { ...prev, tasks: newTasks } : prev);
+      setDao((prev) => (prev ? { ...prev, tasks: newTasks } : prev));
 
       // Send reorder request to backend
-      const taskIds = newTasks.map(task => task.id);
+      const taskIds = newTasks.map((task) => task.id);
       const updatedDao = await taskService.reorderTasks(dao.id, taskIds);
       setDao(updatedDao);
 
@@ -1091,7 +1091,12 @@ export default function DaoDetail() {
               <AddTaskButton
                 onTaskAdd={handleTaskAdd}
                 existingTaskIds={dao.tasks.map((t) => t.id)}
-                canManage={isAdmin() || dao.equipe.some((m) => m.id === user?.id && m.role === "chef_equipe")}
+                canManage={
+                  isAdmin() ||
+                  dao.equipe.some(
+                    (m) => m.id === user?.id && m.role === "chef_equipe",
+                  )
+                }
               />
             </div>
 

--- a/frontend/utils/permissions.ts
+++ b/frontend/utils/permissions.ts
@@ -1,11 +1,17 @@
 import type { AuthUser, Dao } from "@shared/dao";
 
-export function isTeamLead(dao: Dao, user: AuthUser | null | undefined): boolean {
+export function isTeamLead(
+  dao: Dao,
+  user: AuthUser | null | undefined,
+): boolean {
   if (!dao || !user) return false;
   return dao.equipe.some((m) => m.id === user.id && m.role === "chef_equipe");
 }
 
-export function canManageDao(dao: Dao, user: AuthUser | null | undefined): boolean {
+export function canManageDao(
+  dao: Dao,
+  user: AuthUser | null | undefined,
+): boolean {
   if (!user) return false;
   return user.role === "admin" || isTeamLead(dao, user);
 }

--- a/frontend/utils/permissions.ts
+++ b/frontend/utils/permissions.ts
@@ -1,0 +1,11 @@
+import type { AuthUser, Dao } from "@shared/dao";
+
+export function isTeamLead(dao: Dao, user: AuthUser | null | undefined): boolean {
+  if (!dao || !user) return false;
+  return dao.equipe.some((m) => m.id === user.id && m.role === "chef_equipe");
+}
+
+export function canManageDao(dao: Dao, user: AuthUser | null | undefined): boolean {
+  if (!user) return false;
+  return user.role === "admin" || isTeamLead(dao, user);
+}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "dev": "concurrently \"pnpm run dev:backend\" \"pnpm run dev:frontend\"",
     "dev:backend": "pnpm run dev:backend:mongo",
     "dev:backend:express": "tsx backend-express/server.ts",
-    "dev:backend:mongo": "tsx watch backend-mongodb/src/index.ts",
+    "dev:backend:mongo": "cd backend-mongodb && pnpm install && pnpm dev",
     "dev:frontend": "vite",
     "dev:frontend-only": "vite",
     "build": "pnpm run build:client && pnpm run build:server",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "scripts": {
     "dev": "concurrently \"pnpm run dev:backend\" \"pnpm run dev:frontend\"",
+    "dev:auto": "node scripts/dev-auto.mjs",
     "dev:backend": "pnpm run dev:backend:express",
     "dev:backend:express": "tsx backend-express/server.ts",
     "dev:backend:mongo": "cd backend-mongodb && pnpm install && pnpm dev",
@@ -28,7 +29,9 @@
     "typecheck": "tsc --noEmit",
     "lint": "eslint frontend backend-express shared --ext .ts,.tsx",
     "audit:security": "pnpm audit",
-    "update:deps": "pnpm update"
+    "update:deps": "pnpm update",
+    "env:generate": "node scripts/generate-env.mjs",
+    "db:queries": "tsx backend-mongodb/src/scripts/db-queries.ts"
   },
   "dependencies": {
     "@types/mongoose": "^5.11.97",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
   },
   "scripts": {
     "dev": "concurrently \"pnpm run dev:backend\" \"pnpm run dev:frontend\"",
-    "dev:backend": "tsx backend-express/server.ts",
+    "dev:backend": "pnpm run dev:backend:mongo",
+    "dev:backend:express": "tsx backend-express/server.ts",
+    "dev:backend:mongo": "tsx watch backend-mongodb/src/index.ts",
     "dev:frontend": "vite",
     "dev:frontend-only": "vite",
     "build": "pnpm run build:client && pnpm run build:server",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "dev": "concurrently \"pnpm run dev:backend\" \"pnpm run dev:frontend\"",
-    "dev:backend": "pnpm run dev:backend:mongo",
+    "dev:backend": "pnpm run dev:backend:express",
     "dev:backend:express": "tsx backend-express/server.ts",
     "dev:backend:mongo": "cd backend-mongodb && pnpm install && pnpm dev",
     "dev:frontend": "vite",

--- a/scripts/dev-auto.mjs
+++ b/scripts/dev-auto.mjs
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process';
+import net from 'node:net';
+
+function checkPort(host, port, timeout = 800) {
+  return new Promise((resolve) => {
+    const socket = new net.Socket();
+    let done = false;
+    const onDone = (ok) => { if (!done) { done = true; socket.destroy(); resolve(ok); } };
+    socket.setTimeout(timeout);
+    socket.once('connect', () => onDone(true));
+    socket.once('timeout', () => onDone(false));
+    socket.once('error', () => onDone(false));
+    socket.connect(port, host);
+  });
+}
+
+async function run() {
+  const mongoUp = await checkPort('127.0.0.1', 27017).catch(() => false);
+  const useMongo = !!mongoUp;
+
+  const envFrontend = { ...process.env, BACKEND_URL: useMongo ? 'http://localhost:5000' : 'http://localhost:3001' };
+
+  const backendCmd = useMongo ? ['run', 'dev:backend:mongo'] : ['run', 'dev:backend:express'];
+  console.log(`🚀 Starting ${useMongo ? 'MongoDB' : 'Express'} backend and Vite (proxy → ${envFrontend.BACKEND_URL})`);
+
+  const backend = spawn('pnpm', backendCmd, { stdio: 'inherit', env: process.env });
+  const frontend = spawn('pnpm', ['run', 'dev:frontend'], { stdio: 'inherit', env: envFrontend });
+
+  const onExit = (code) => process.exit(code ?? 0);
+  backend.on('exit', onExit);
+  frontend.on('exit', onExit);
+}
+
+run();

--- a/scripts/dev-auto.mjs
+++ b/scripts/dev-auto.mjs
@@ -1,35 +1,54 @@
 #!/usr/bin/env node
-import { spawn } from 'node:child_process';
-import net from 'node:net';
+import { spawn } from "node:child_process";
+import net from "node:net";
 
 function checkPort(host, port, timeout = 800) {
   return new Promise((resolve) => {
     const socket = new net.Socket();
     let done = false;
-    const onDone = (ok) => { if (!done) { done = true; socket.destroy(); resolve(ok); } };
+    const onDone = (ok) => {
+      if (!done) {
+        done = true;
+        socket.destroy();
+        resolve(ok);
+      }
+    };
     socket.setTimeout(timeout);
-    socket.once('connect', () => onDone(true));
-    socket.once('timeout', () => onDone(false));
-    socket.once('error', () => onDone(false));
+    socket.once("connect", () => onDone(true));
+    socket.once("timeout", () => onDone(false));
+    socket.once("error", () => onDone(false));
     socket.connect(port, host);
   });
 }
 
 async function run() {
-  const mongoUp = await checkPort('127.0.0.1', 27017).catch(() => false);
+  const mongoUp = await checkPort("127.0.0.1", 27017).catch(() => false);
   const useMongo = !!mongoUp;
 
-  const envFrontend = { ...process.env, BACKEND_URL: useMongo ? 'http://localhost:5000' : 'http://localhost:3001' };
+  const envFrontend = {
+    ...process.env,
+    BACKEND_URL: useMongo ? "http://localhost:5000" : "http://localhost:3001",
+  };
 
-  const backendCmd = useMongo ? ['run', 'dev:backend:mongo'] : ['run', 'dev:backend:express'];
-  console.log(`🚀 Starting ${useMongo ? 'MongoDB' : 'Express'} backend and Vite (proxy → ${envFrontend.BACKEND_URL})`);
+  const backendCmd = useMongo
+    ? ["run", "dev:backend:mongo"]
+    : ["run", "dev:backend:express"];
+  console.log(
+    `🚀 Starting ${useMongo ? "MongoDB" : "Express"} backend and Vite (proxy → ${envFrontend.BACKEND_URL})`,
+  );
 
-  const backend = spawn('pnpm', backendCmd, { stdio: 'inherit', env: process.env });
-  const frontend = spawn('pnpm', ['run', 'dev:frontend'], { stdio: 'inherit', env: envFrontend });
+  const backend = spawn("pnpm", backendCmd, {
+    stdio: "inherit",
+    env: process.env,
+  });
+  const frontend = spawn("pnpm", ["run", "dev:frontend"], {
+    stdio: "inherit",
+    env: envFrontend,
+  });
 
   const onExit = (code) => process.exit(code ?? 0);
-  backend.on('exit', onExit);
-  frontend.on('exit', onExit);
+  backend.on("exit", onExit);
+  frontend.on("exit", onExit);
 }
 
 run();

--- a/scripts/generate-env.mjs
+++ b/scripts/generate-env.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
-import { writeFileSync, existsSync, mkdirSync } from 'node:fs';
-import { randomBytes } from 'node:crypto';
-import { join, dirname } from 'node:path';
+import { writeFileSync, existsSync, mkdirSync } from "node:fs";
+import { randomBytes } from "node:crypto";
+import { join, dirname } from "node:path";
 
 function ensureDir(file) {
   const dir = dirname(file);
@@ -9,21 +9,21 @@ function ensureDir(file) {
 }
 
 function genSecret(bytes = 48) {
-  return randomBytes(bytes).toString('hex');
+  return randomBytes(bytes).toString("hex");
 }
 
 function writeEnv(filePath, lines) {
   ensureDir(filePath);
   if (!existsSync(filePath)) {
-    writeFileSync(filePath, lines.join('\n') + '\n', { encoding: 'utf8' });
+    writeFileSync(filePath, lines.join("\n") + "\n", { encoding: "utf8" });
     console.log(`✅ Created ${filePath}`);
   } else {
     console.log(`ℹ️  Skipped, exists: ${filePath}`);
   }
 }
 
-const rootEnv = join(process.cwd(), '.env');
-const mongoEnv = join(process.cwd(), 'backend-mongodb/.env');
+const rootEnv = join(process.cwd(), ".env");
+const mongoEnv = join(process.cwd(), "backend-mongodb/.env");
 
 const jwt1 = genSecret();
 const jwt2 = genSecret();

--- a/scripts/generate-env.mjs
+++ b/scripts/generate-env.mjs
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+import { writeFileSync, existsSync, mkdirSync } from 'node:fs';
+import { randomBytes } from 'node:crypto';
+import { join, dirname } from 'node:path';
+
+function ensureDir(file) {
+  const dir = dirname(file);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+}
+
+function genSecret(bytes = 48) {
+  return randomBytes(bytes).toString('hex');
+}
+
+function writeEnv(filePath, lines) {
+  ensureDir(filePath);
+  if (!existsSync(filePath)) {
+    writeFileSync(filePath, lines.join('\n') + '\n', { encoding: 'utf8' });
+    console.log(`✅ Created ${filePath}`);
+  } else {
+    console.log(`ℹ️  Skipped, exists: ${filePath}`);
+  }
+}
+
+const rootEnv = join(process.cwd(), '.env');
+const mongoEnv = join(process.cwd(), 'backend-mongodb/.env');
+
+const jwt1 = genSecret();
+const jwt2 = genSecret();
+
+writeEnv(rootEnv, [
+  `PORT=3001`,
+  `FRONTEND_URL=http://localhost:8080`,
+  `PING_MESSAGE=pong - secure`,
+  `JWT_SECRET=${jwt1}`,
+  `JWT_EXPIRES_IN=24h`,
+]);
+
+writeEnv(mongoEnv, [
+  `PORT=5000`,
+  `FRONTEND_URL=http://localhost:8080`,
+  `MONGODB_URI=mongodb://localhost:27017/dao-management`,
+  `JWT_SECRET=${jwt2}`,
+  `JWT_EXPIRES_IN=7d`,
+]);

--- a/scripts/setup-local.sh
+++ b/scripts/setup-local.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+OS="$(uname -s)"
+echo "🔧 Local setup starting on: $OS"
+
+# 1) Ensure pnpm
+if ! command -v pnpm >/dev/null 2>&1; then
+  echo "📦 Installing pnpm..."
+  npm i -g pnpm
+fi
+
+# 2) Install MongoDB Community (best effort)
+if ! nc -z 127.0.0.1 27017 >/dev/null 2>&1; then
+  case "$OS" in
+    Darwin)
+      if ! command -v brew >/dev/null 2>&1; then
+        echo "🍺 Homebrew not found. Install from https://brew.sh then re-run this script."; exit 1;
+      fi
+      brew tap mongodb/brew
+      brew install mongodb-community@7.0
+      brew services start mongodb-community@7.0
+      ;;
+    Linux)
+      if command -v apt >/dev/null 2>&1; then
+        echo "🐧 Installing MongoDB via apt..."
+        sudo apt-get update -y
+        sudo apt-get install -y gnupg curl
+        curl -fsSL https://pgp.mongodb.com/server-7.0.asc | sudo gpg -o /usr/share/keyrings/mongodb-server-7.0.gpg --dearmor
+        echo "deb [ signed-by=/usr/share/keyrings/mongodb-server-7.0.gpg ] https://repo.mongodb.org/apt/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME)/mongodb-org/7.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-7.0.list
+        sudo apt-get update -y
+        sudo apt-get install -y mongodb-org
+        sudo systemctl enable mongod
+        sudo systemctl start mongod
+      else
+        echo "⚠️  Please install MongoDB Community for your distro manually: https://www.mongodb.com/docs/manual/administration/install-on-linux/"
+      fi
+      ;;
+    *)
+      echo "⚠️  Unsupported OS for auto-install. Install MongoDB manually: https://www.mongodb.com/try/download/community";;
+  esac
+else
+  echo "✅ MongoDB already running on 27017"
+fi
+
+# 3) Install dependencies
+pnpm install
+
+# 4) Generate env files with strong secrets
+pnpm run env:generate
+
+# 5) Install backend-mongodb deps
+( cd backend-mongodb && pnpm install )
+
+# 6) Done: suggest auto dev
+cat <<EOF
+
+🎉 Setup completed.
+Run one of:
+  pnpm dev:auto        # Auto-switch backend (Mongo if available, else Express)
+  pnpm dev             # Current default (Express backend)
+  pnpm db:queries      # Sample DB queries against Mongo
+
+EOF

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
     port: 8080,
     proxy: {
       "/api": {
-        target: "http://localhost:3001", // Express backend port
+        target: "http://localhost:5000", // MongoDB backend port
         changeOrigin: true,
         secure: false,
       },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
     port: 8080,
     proxy: {
       "/api": {
-        target: "http://localhost:5000", // MongoDB backend port
+        target: "http://localhost:3001", // Express backend port
         changeOrigin: true,
         secure: false,
       },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,8 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import path from "path";
 
+const backendTarget = process.env.BACKEND_URL || "http://localhost:3001";
+
 export default defineConfig({
   plugins: [react()],
   resolve: {
@@ -14,7 +16,7 @@ export default defineConfig({
     port: 8080,
     proxy: {
       "/api": {
-        target: "http://localhost:3001", // Express backend port
+        target: backendTarget,
         changeOrigin: true,
         secure: false,
       },


### PR DESCRIPTION
## Purpose

The user "Marie" was assigned as team leader (chef d'équipe) for a DAO but lacked the necessary permissions to manage tasks and assignments within that DAO. The system needed to implement proper role-based access control where team leaders have management rights only for DAOs they are assigned to lead.

## Code changes

- **Backend permissions**: Added `requireDaoLeaderOrAdmin` middleware to check if user is either admin or team leader for specific DAO
- **Route protection**: Updated DAO and task routes to use new permission middleware instead of generic `requireUser`/`requireAdmin`
- **Mock data**: Fixed user ID inconsistencies in test data to ensure proper permission testing
- **Frontend permissions**: Added permission utility functions and conditional UI rendering based on user role
- **Development setup**: Added MongoDB support with auto-detection, environment generation scripts, and improved development workflow
- **Database queries**: Added sample MongoDB query scripts for DAO management operations

The fix ensures team leaders can only manage DAOs they are assigned to, while admins retain full access across all DAOs.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 9`

🔗 [Edit in Builder.io](https://builder.io/app/projects/d01dc92005f2456790af8652837f52dd/mystic-studio)

👀 [Preview Link](https://d01dc92005f2456790af8652837f52dd-mystic-studio.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d01dc92005f2456790af8652837f52dd</projectId>-->
<!--<branchName>mystic-studio</branchName>-->